### PR TITLE
latest version jekyll 3.0.1  command has been changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ To development it locally:
 
 ```bash
 gem install jekyll redcarpet
-jekyll --server --auto
+jekyll serve watch
 ```
-
 Then point a browser to http://localhost:4000.


### PR DESCRIPTION
Deprecation: The --server command has been replaced by the 'serve' subcommand.
Deprecation: The switch '--auto' has been replaced with '--watch'.
Deprecation: Jekyll now uses subcommands instead of just switches.
